### PR TITLE
Generalize layout for rectangle surface codes

### DIFF
--- a/qec_util/layouts/layout.py
+++ b/qec_util/layouts/layout.py
@@ -48,9 +48,13 @@ class Layout:
             )
 
         self.name = setup.get("name")
+        self.distance_x = setup.get("distance_x")
+        self.distance_z = setup.get("distance_z")
         self.distance = setup.get("distance")
         self.description = setup.get("description")
         self.interaction_order = setup.get("interaction_order")
+        self.log_z = setup.get("log_z")
+        self.log_x = setup.get("log_x")
 
         self.graph = nx.DiGraph()
         self._load_layout(setup)

--- a/qec_util/layouts/library.py
+++ b/qec_util/layouts/library.py
@@ -44,7 +44,7 @@ def rot_surf_code_rectangle(distance_x: int, distance_z: int) -> Layout:
     _check_distance(distance_x)
     _check_distance(distance_z)
 
-    name = f"Rotated d-{distance} surface code layout."
+    name = f"Rotated dx-{distance_x} dz-{distance_z} surface code layout."
     description = None
 
     freq_order = ["low", "mid", "high"]
@@ -54,13 +54,21 @@ def rot_surf_code_rectangle(distance_x: int, distance_z: int) -> Layout:
         z_type=["north_east", "south_east", "north_west", "south_west"],
     )
 
+    log_z = [f"D{i+1}" for i in range(distance_z)]
+    log_x = [f"D{i*distance_z+1}" for i in range(distance_x)]
+
     layout_setup = dict(
         name=name,
         description=description,
-        distance=distance,
+        distance_x=distance_x,
+        distance_z=distance_z,
         freq_order=freq_order,
         interaction_order=int_order,
+        log_z=log_z,
+        log_x=log_x,
     )
+    if distance_x == distance_z:
+        layout_setup["distance"] = distance_z
 
     col_size = 2 * distance_z + 1
     row_size = 2 * distance_x + 1


### PR DESCRIPTION
Added option for rectangle rotated surface codes. 
This functionality is needed for the logical S gate experiment, where we need a code of size `d x (d+1)`

It can reproduce the square layouts:

![Selection_171](https://github.com/BorisVarbanov/qec-util/assets/43704266/5fdb1918-bd0a-4227-b0a2-ef5c6a9edef7)

It can generate rectangle layouts:

![Selection_172](https://github.com/BorisVarbanov/qec-util/assets/43704266/dbfc3cc9-9040-495d-8db1-7ea83c9607ff)
